### PR TITLE
Add chassis flat imagery for panel overlay previews

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -97,6 +97,7 @@ header p {
 .eyebrow { text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.75rem; color: #94a3b8; margin: 0; }
 .muted { color: #94a3b8; }
 .small { font-size: 0.85rem; }
+.micro { font-size: 0.75rem; color: #cbd5e1; opacity: 0.75; margin: -0.25rem 0 0; }
 
 .panel-upload { margin: 0.75rem 0; display: grid; gap: 0.35rem; }
 .upload-label { padding: 0.65rem; border: 1px dashed rgba(226, 232, 240, 0.2); border-radius: 10px; background: rgba(255, 255, 255, 0.04); cursor: pointer; display: inline-block; width: fit-content; }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import './App.css'
 import PanelPreview from './components/PanelPreview'
+import frontGlass from './assets/chassis/front-glass.svg'
+import sideMesh from './assets/chassis/side-mesh.svg'
+import frontAngle from './assets/chassis/front-angle.svg'
 
 const baseChassis = {
   name: 'Lian Li O11 Dynamic EVO',
@@ -12,6 +15,8 @@ const baseChassis = {
       label: 'Tempered glass',
       name: 'Front showcase window',
       finish: 'Print-ready',
+      preview: frontGlass,
+      hotspot: 'Full height glass for hero artwork. 400mm x 450mm normalised space.',
       desc: 'Use UV-cured ink for vibrant colours. Uploads are centred and can be offset for logo placement.',
     },
     {
@@ -19,7 +24,18 @@ const baseChassis = {
       label: 'Ventilated steel',
       name: 'Side mesh panel',
       finish: 'Breathable',
+      preview: sideMesh,
+      hotspot: 'Mesh intake surface. Leave light spill-through for airflow.',
       desc: 'Optimised for breathable graphics. Keep opacity under 90% to preserve ventilation.',
+    },
+    {
+      id: 'angle-proof',
+      label: 'Assembly proof',
+      name: 'Perspective reference',
+      finish: 'Visualizer',
+      preview: frontAngle,
+      hotspot: 'Use to sanity check alignment across glass + mesh before exporting.',
+      desc: 'Reference-only angle that mirrors the product photography provided.',
     },
   ],
   quickNotes: [

--- a/src/assets/chassis/front-angle.svg
+++ b/src/assets/chassis/front-angle.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="1200" viewBox="0 0 1200 1200" fill="none">
+  <defs>
+    <linearGradient id="edge" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0b111b" />
+    </linearGradient>
+    <linearGradient id="angleGlass" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.5" />
+      <stop offset="40%" stop-color="#a855f7" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#14b8a6" stop-opacity="0.25" />
+    </linearGradient>
+    <pattern id="honey" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="#0e1422" />
+      <circle cx="8" cy="8" r="4" fill="#111827" />
+    </pattern>
+  </defs>
+  <rect x="220" y="120" width="620" height="960" rx="38" fill="#0b1020" stroke="#1f2937" stroke-width="4"/>
+  <path d="M220 160 L760 120 L960 240 L960 1040 L820 1080 L220 1070 Z" fill="#0f172a" stroke="#1e293b" stroke-width="4" />
+  <path d="M265 190 L760 150 L910 260 L910 980 L800 1020 L265 1010 Z" fill="url(#angleGlass)" stroke="#38bdf8" stroke-opacity="0.35" stroke-width="3" />
+  <path d="M760 120 L960 240 L960 1040 L760 920 Z" fill="url(#edge)" />
+  <path d="M910 260 L960 240 L960 1040 L910 980 Z" fill="url(#edge)" opacity="0.9"/>
+  <path d="M820 280 L890 250 L890 780 L820 820 Z" fill="url(#honey)" opacity="0.85" />
+  <rect x="320" y="135" width="260" height="18" rx="6" fill="#cbd5e1" opacity="0.28" />
+  <rect x="320" y="1048" width="260" height="18" rx="6" fill="#cbd5e1" opacity="0.2" />
+  <rect x="910" y="1060" width="70" height="24" rx="8" fill="#0ea5e9" opacity="0.4" />
+  <path d="M220 520 L760 480 L760 920 L220 880 Z" fill="url(#honey)" opacity="0.15" />
+  <text x="510" y="1160" font-family="'Inter', 'Segoe UI', sans-serif" font-size="28" fill="#cbd5e1" text-anchor="middle" opacity="0.85">Perspective glass + mesh reference</text>
+</svg>

--- a/src/assets/chassis/front-glass.svg
+++ b/src/assets/chassis/front-glass.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="1200" viewBox="0 0 800 1200" fill="none">
+  <defs>
+    <linearGradient id="glassGlow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.55"/>
+      <stop offset="35%" stop-color="#6366f1" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#0ea5e9" stop-opacity="0.15"/>
+    </linearGradient>
+    <linearGradient id="brushed" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0b111b" />
+    </linearGradient>
+    <pattern id="vent" x="0" y="0" width="14" height="14" patternUnits="userSpaceOnUse">
+      <rect width="14" height="14" fill="#0f1626"/>
+      <circle cx="7" cy="7" r="3.2" fill="#1f2937" />
+    </pattern>
+  </defs>
+  <rect x="70" y="40" width="660" height="1120" rx="40" fill="#0b1020" stroke="#1f2937" stroke-width="4"/>
+  <rect x="110" y="90" width="440" height="1020" rx="24" fill="#0f172a" stroke="#1e293b" stroke-width="4"/>
+  <rect x="120" y="100" width="420" height="1000" rx="22" fill="url(#glassGlow)" stroke="#38bdf8" stroke-opacity="0.35" stroke-width="3"/>
+  <rect x="580" y="140" width="90" height="900" rx="16" fill="#111827" stroke="#1f2937" stroke-width="3"/>
+  <rect x="590" y="160" width="70" height="860" rx="14" fill="url(#vent)" opacity="0.8"/>
+  <rect x="560" y="40" width="130" height="1120" rx="28" fill="url(#brushed)" />
+  <rect x="560" y="40" width="130" height="1120" rx="28" stroke="#334155" stroke-width="4" fill="none" opacity="0.5"/>
+  <rect x="560" y="70" width="130" height="80" rx="18" fill="#111827" stroke="#1f2937" stroke-width="3" opacity="0.9"/>
+  <rect x="590" y="1040" width="70" height="30" rx="8" fill="#0ea5e9" opacity="0.45"/>
+  <rect x="300" y="80" width="220" height="12" rx="4" fill="#94a3b8" opacity="0.35"/>
+  <rect x="300" y="1104" width="220" height="12" rx="4" fill="#94a3b8" opacity="0.25"/>
+  <text x="400" y="1160" font-family="'Inter', 'Segoe UI', sans-serif" font-size="26" fill="#cbd5e1" text-anchor="middle" opacity="0.85">Front tempered glass</text>
+</svg>

--- a/src/assets/chassis/side-mesh.svg
+++ b/src/assets/chassis/side-mesh.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="1200" viewBox="0 0 800 1200" fill="none">
+  <defs>
+    <linearGradient id="meshBody" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1d2533" />
+      <stop offset="100%" stop-color="#0e1422" />
+    </linearGradient>
+    <pattern id="mesh" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse">
+      <rect width="18" height="18" fill="#0f1827" />
+      <circle cx="9" cy="9" r="4.5" fill="#111827" />
+      <circle cx="9" cy="9" r="2.5" fill="#1f2937" />
+    </pattern>
+  </defs>
+  <rect x="70" y="60" width="660" height="1080" rx="34" fill="#0b1020" stroke="#1f2937" stroke-width="4"/>
+  <rect x="110" y="100" width="580" height="1000" rx="26" fill="url(#meshBody)" stroke="#1e293b" stroke-width="3"/>
+  <rect x="135" y="130" width="530" height="940" rx="22" fill="url(#mesh)" opacity="0.92"/>
+  <rect x="120" y="115" width="560" height="970" rx="24" stroke="#334155" stroke-width="2.5" opacity="0.55"/>
+  <rect x="140" y="160" width="80" height="50" rx="12" fill="#1f2937" opacity="0.8"/>
+  <rect x="220" y="160" width="80" height="50" rx="12" fill="#1f2937" opacity="0.7"/>
+  <rect x="300" y="160" width="80" height="50" rx="12" fill="#1f2937" opacity="0.6"/>
+  <rect x="380" y="160" width="80" height="50" rx="12" fill="#1f2937" opacity="0.5"/>
+  <rect x="460" y="160" width="80" height="50" rx="12" fill="#1f2937" opacity="0.4"/>
+  <rect x="540" y="160" width="80" height="50" rx="12" fill="#1f2937" opacity="0.3"/>
+  <rect x="325" y="1040" width="150" height="35" rx="10" fill="#0ea5e9" opacity="0.5"/>
+  <text x="400" y="1165" font-family="'Inter', 'Segoe UI', sans-serif" font-size="26" fill="#cbd5e1" text-anchor="middle" opacity="0.85">Side mesh panel</text>
+</svg>

--- a/src/components/PCCase.jsx
+++ b/src/components/PCCase.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { useTexture } from '@react-three/drei'
+import { RepeatWrapping } from 'three'
 
 function PCCase({ caseSpec, motherboardSpec, gpuSpec, panelOverlay, placeholderTexture }) {
   const groupRef = useRef()
@@ -19,10 +20,14 @@ function PCCase({ caseSpec, motherboardSpec, gpuSpec, panelOverlay, placeholderT
   }, [caseSpec])
 
   const panelTexture = useTexture(panelOverlay?.image || placeholderTexture)
-  if (panelTexture) {
-    panelTexture.wrapS = panelTexture.wrapT = 1000
-    panelTexture.repeat.set(panelOverlay.scale, panelOverlay.scale)
-  }
+  const configuredTexture = useMemo(() => {
+    if (!panelTexture) return null
+    const clone = panelTexture.clone()
+    clone.wrapS = clone.wrapT = RepeatWrapping
+    clone.repeat.set(panelOverlay.scale, panelOverlay.scale)
+    clone.needsUpdate = true
+    return clone
+  }, [panelOverlay.scale, panelTexture])
 
   const motherboardWidth = motherboardSpec?.formFactor === 'microatx' ? 0.9 : 1.1
   const motherboardDepth = motherboardSpec?.formFactor === 'microatx' ? 0.9 : 1.1
@@ -107,7 +112,7 @@ function PCCase({ caseSpec, motherboardSpec, gpuSpec, panelOverlay, placeholderT
 
       <mesh position={[dimensions.width / 2 + 0.03 + panelOverlay.position.x, 0, 0]} castShadow>
         <planeGeometry args={[dimensions.height * 0.9 * panelOverlay.scale, dimensions.height * 0.9 * panelOverlay.scale]} />
-        <meshStandardMaterial map={panelTexture} transparent opacity={panelOverlay.opacity} side={2} />
+        <meshStandardMaterial map={configuredTexture} transparent opacity={panelOverlay.opacity} side={2} />
       </mesh>
 
       {[-1, 1].map((x) =>

--- a/src/components/PanelPreview.css
+++ b/src/components/PanelPreview.css
@@ -50,6 +50,9 @@
   background: linear-gradient(135deg, #0b1020, #0f172a);
   overflow: hidden;
   border: 1px solid rgba(226, 232, 240, 0.08);
+  background-size: cover;
+  background-position: center;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
 }
 
 .panel {
@@ -72,6 +75,13 @@
   background: linear-gradient(180deg, rgba(99, 102, 241, 0.08), rgba(99, 102, 241, 0.02));
 }
 
+.panel-angle-proof {
+  inset: 16%;
+  border: 1px solid rgba(236, 72, 153, 0.28);
+  background: linear-gradient(180deg, rgba(236, 72, 153, 0.08), rgba(56, 189, 248, 0.04));
+  box-shadow: inset 0 0 0 1px rgba(236, 72, 153, 0.25);
+}
+
 .panel-overlay {
   position: absolute;
   inset: 14%;
@@ -81,6 +91,8 @@
   transition: transform 0.25s ease, opacity 0.25s ease;
   mix-blend-mode: screen;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: saturate(120%);
 }
 
 @media (max-width: 768px) {

--- a/src/components/PanelPreview.jsx
+++ b/src/components/PanelPreview.jsx
@@ -31,13 +31,17 @@ function PanelPreview({ chassis, panelOverlay, placeholderTexture }) {
             </div>
 
             <div className="surface-frame">
-              <div className="case-shell">
+              <div
+                className="case-shell"
+                style={{ backgroundImage: surface.preview ? `url(${surface.preview})` : undefined }}
+              >
                 <div className={`panel panel-${surface.id}`}> </div>
                 <div className="panel-overlay" style={overlayStyle} />
               </div>
             </div>
 
             <p className="muted small">{surface.desc}</p>
+            {surface.hotspot ? <p className="muted micro">{surface.hotspot}</p> : null}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add SVG flat renders for front glass, side mesh, and angled reference panels
- surface the new chassis artwork inside the preview cards with hotspot guidance text
- keep the overlay texture configuration compatible with lint rules

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396a344bec832b8da7fb4a9cf91e3b)